### PR TITLE
feat: nuc builder

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,0 +1,122 @@
+import * as crypto from "node:crypto";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import type { Temporal } from "temporal-polyfill";
+import type { NucTokenEnvelope } from "#/envelope";
+import {
+  type Command,
+  DelegationBody,
+  Did,
+  InvocationBody,
+  NucToken,
+  NucTokenDataSchema,
+} from "#/token";
+import type { Policy } from "#/types";
+import { base64UrlEncode } from "#/utils";
+
+const DEFAULT_NONCE_LENGTH = 16;
+
+export class NucTokenBuilder {
+  private _audience?: Did;
+  private _subject?: Did;
+  private _notBefore?: Temporal.Instant;
+  private _expiresAt?: Temporal.Instant;
+  private _command?: Command;
+  private _meta?: Record<string, unknown>;
+  private _nonce?: Uint8Array;
+  private _proof?: NucTokenEnvelope;
+
+  private constructor(private _body: DelegationBody | InvocationBody) {}
+
+  static delegation(policies: Array<Policy>): NucTokenBuilder {
+    return new NucTokenBuilder(new DelegationBody(policies));
+  }
+
+  static invocation(args: Record<string, unknown>): NucTokenBuilder {
+    return new NucTokenBuilder(new InvocationBody(args));
+  }
+
+  static extending(envelope: NucTokenEnvelope): NucTokenBuilder {
+    const token = envelope.token;
+    if (token.token.body instanceof InvocationBody) {
+      throw Error("cannot extend an invocation");
+    }
+    return new NucTokenBuilder(token.token.body)
+      .proof(envelope)
+      .command(token.token.command)
+      .subject(token.token.subject);
+  }
+
+  audience(audience: Did): NucTokenBuilder {
+    this._audience = audience;
+    return this;
+  }
+
+  subject(subject: Did): NucTokenBuilder {
+    this._subject = subject;
+    return this;
+  }
+
+  notBefore(notBefore: Temporal.Instant): NucTokenBuilder {
+    this._notBefore = notBefore;
+    return this;
+  }
+
+  expiresAt(expiresAt: Temporal.Instant): NucTokenBuilder {
+    this._expiresAt = expiresAt;
+    return this;
+  }
+
+  command(command: Command): NucTokenBuilder {
+    this._command = command;
+    return this;
+  }
+
+  meta(meta: Record<string, unknown>): NucTokenBuilder {
+    this._meta = meta;
+    return this;
+  }
+
+  nonce(nonce: Uint8Array): NucTokenBuilder {
+    this._nonce = nonce;
+    return this;
+  }
+
+  proof(proof: NucTokenEnvelope): NucTokenBuilder {
+    this._proof = proof;
+    return this;
+  }
+
+  build(key: Uint8Array): string {
+    const proof = this._proof;
+    if (proof) {
+      proof.validateSignatures();
+    }
+    const data = NucTokenDataSchema.parse({
+      body: this._body,
+      issuer: new Did(secp256k1.getPublicKey(key, true)),
+      audience: this._audience,
+      subject: this._subject,
+      notBefore: this._notBefore,
+      expiresAt: this._expiresAt,
+      command: this._command,
+      meta: this._meta,
+      nonce: this._nonce
+        ? this._nonce
+        : crypto.randomBytes(DEFAULT_NONCE_LENGTH),
+      proofs: proof ? [proof.token.computeHash()] : [],
+    });
+    let token = base64UrlEncode(new NucToken(data).toString());
+    const header = base64UrlEncode('{"alg":"ES256K"}');
+    token = `${header}.${token}`;
+
+    const msg = Uint8Array.from(Buffer.from(token));
+    const signature = secp256k1.sign(msg, key, { prehash: true });
+
+    token = `${token}.${base64UrlEncode(signature.toCompactRawBytes())}`;
+    if (this._proof) {
+      const allProofs = [this._proof.token, ...this._proof.proofs];
+      token = `${token}/${allProofs.map((proof) => proof.toString()).join("/")}`;
+    }
+    return token;
+  }
+}

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -1,19 +1,41 @@
-import type { Selector } from "#/types";
+import { z } from "zod";
 
-export function applySelector<T = unknown>(
-  selector: Selector,
-  value: unknown,
-): T {
-  let result = value;
-  for (const label of selector) {
-    if (result !== null && typeof result === "object") {
-      const record = result as Record<string, unknown>;
-      if (label in record) {
-        result = record[label];
-      } else {
-        return undefined as T;
+const ALPHABET_LABEL = /[a-zA-Z0-9_-]+/;
+
+export const SelectorSchema = z
+  .string()
+  .startsWith(".", "selector must start with '.'")
+  .transform((selector) => {
+    const s = selector.slice(1);
+    if (!s) return [];
+    return s.split(".");
+  })
+  .refine((labels) => labels.every(Boolean), "empty attribute")
+  .refine(
+    (labels) => labels.every((label) => ALPHABET_LABEL.test(label)),
+    "invalid attribute character",
+  )
+  .transform((labels) => new Selector(labels));
+
+export class Selector {
+  constructor(private readonly path: Array<string>) {}
+
+  apply<T = unknown>(value: unknown): T {
+    let result = value;
+    for (const label of this.path) {
+      if (result !== null && typeof result === "object") {
+        const record = result as Record<string, unknown>;
+        if (label in record) {
+          result = record[label];
+        } else {
+          return undefined as T;
+        }
       }
     }
+    return result as T;
   }
-  return result as T;
+
+  toString(): string {
+    return `.${this.path.join(".")}`;
+  }
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,5 +1,15 @@
-import type { Temporal } from "temporal-polyfill";
-import type { Command, DelegationBody, InvocationBody } from "#/types";
+import { Temporal } from "temporal-polyfill";
+import { z } from "zod";
+import { serializePolicy } from "#/policy";
+import { type Policy, PolicySchema } from "#/types";
+
+const DID_EXPRESSION = /^did:nil:([a-zA-Z0-9]{66})$/;
+
+export const DidSchema = z
+  .string()
+  .transform((did) => DID_EXPRESSION.exec(did))
+  .refine((match) => match !== null, "invalid DID")
+  .transform((match) => Did.fromHex(match[1]));
 
 export class Did {
   constructor(public readonly publicKey: Uint8Array) {}
@@ -13,59 +23,165 @@ export class Did {
   }
 }
 
+export const CommandSchema = z
+  .string()
+  .startsWith("/", "command must start with '/'")
+  .transform((selector) => {
+    const s = selector.slice(1);
+    if (!s) return [];
+    return s.split("/");
+  })
+  .refine((labels) => labels.every(Boolean), "empty command")
+  .transform((segments) => {
+    return new Command(segments);
+  });
+
+export class Command {
+  constructor(public readonly segments: Array<string>) {}
+
+  toString(): string {
+    return `/${this.segments.join("/")}`;
+  }
+}
+
+export const InvocationBodySchema = z
+  .record(z.string(), z.unknown())
+  .transform((args) => new InvocationBody(args));
+
+export class InvocationBody {
+  constructor(public readonly args: Record<string, unknown>) {}
+}
+
+export const DelegationBodySchema = z
+  .array(PolicySchema)
+  .transform((body) => new DelegationBody(body));
+
+export class DelegationBody {
+  constructor(public readonly policies: Array<Policy>) {}
+}
+
+export const NucTokenSchema = z
+  .object({
+    iss: DidSchema,
+    aud: DidSchema,
+    sub: DidSchema,
+    nbf: z.number().optional(),
+    exp: z.number().optional(),
+    cmd: CommandSchema,
+    args: InvocationBodySchema.optional(),
+    pol: DelegationBodySchema.optional(),
+    meta: z.record(z.string(), z.unknown()).optional(),
+    nonce: z.string(),
+    prf: z.array(z.string()).default([]),
+  })
+  .transform((token) => {
+    return new NucToken({
+      issuer: token.iss,
+      audience: token.aud,
+      subject: token.sub,
+      command: token.cmd,
+      body: tokenBody(token.args, token.pol),
+      nonce: new Uint8Array(Buffer.from(token.nonce, "hex")),
+      proofs: token.prf.map((prf) => new Uint8Array(Buffer.from(prf, "hex"))),
+      notBefore: token.nbf
+        ? Temporal.Instant.fromEpochMilliseconds(token.nbf)
+        : undefined,
+      expiresAt: token.exp
+        ? Temporal.Instant.fromEpochMilliseconds(token.exp)
+        : undefined,
+      meta: token.meta,
+    });
+  });
+
+function tokenBody(
+  args: InvocationBody | undefined,
+  pol: DelegationBody | undefined,
+): InvocationBody | DelegationBody {
+  if (args !== undefined && pol !== undefined)
+    throw Error("one of 'args' and 'pol' must be set");
+  if (args !== undefined) return args;
+  if (pol !== undefined) return pol;
+  throw Error("'args' and 'pol' can't both be set");
+}
+
+export const NucTokenDataSchema = z.object({
+  issuer: z.instanceof(Did),
+  audience: z.instanceof(Did),
+  subject: z.instanceof(Did),
+  notBefore: z.instanceof(Temporal.Instant).optional(),
+  expiresAt: z.instanceof(Temporal.Instant).optional(),
+  command: z.instanceof(Command),
+  body: z.union([z.instanceof(DelegationBody), z.instanceof(InvocationBody)]),
+  meta: z.record(z.string(), z.unknown()).optional(),
+  nonce: z.instanceof(Uint8Array),
+  proofs: z.array(z.instanceof(Uint8Array)),
+});
+
+export type NucTokenData = z.infer<typeof NucTokenDataSchema>;
+
 export class NucToken {
-  constructor(
-    private readonly data: {
-      issuer: Did;
-      audience: Did;
-      subject: Did;
-      command: Command;
-      body: DelegationBody | InvocationBody;
-      nonce: Uint8Array;
-      proofs?: Array<Uint8Array>;
-      notBefore?: Temporal.Instant;
-      expiresAt?: Temporal.Instant;
-      meta?: Record<string, unknown>;
-    },
-  ) {}
+  constructor(private readonly _data: NucTokenData) {}
 
   get issuer(): Did {
-    return this.data.issuer;
+    return this._data.issuer;
   }
 
   get audience(): Did {
-    return this.data.audience;
+    return this._data.audience;
   }
 
   get subject(): Did {
-    return this.data.subject;
+    return this._data.subject;
   }
 
   get command(): Command {
-    return this.data.command;
+    return this._data.command;
   }
 
   get body(): InvocationBody | DelegationBody {
-    return this.data.body;
+    return this._data.body;
   }
 
   get nonce(): Uint8Array {
-    return this.data.nonce;
+    return this._data.nonce;
   }
 
   get proofs(): Array<Uint8Array> {
-    return this.data.proofs ? this.data.proofs : [];
+    return this._data.proofs ? this._data.proofs : [];
   }
 
   get notBefore(): Temporal.Instant | undefined {
-    return this.data.notBefore;
+    return this._data.notBefore;
   }
 
   get expiresAt(): Temporal.Instant | undefined {
-    return this.data.expiresAt;
+    return this._data.expiresAt;
   }
 
   get meta(): Record<string, unknown> | undefined {
-    return this.data.meta;
+    return this._data.meta;
+  }
+
+  toString(): string {
+    const token: Record<string, unknown> = {
+      iss: this.issuer.toString(),
+      aud: this.audience.toString(),
+      sub: this.subject.toString(),
+      nbf: this.notBefore ? this.notBefore.epochMilliseconds : undefined,
+      exp: this.expiresAt ? this.expiresAt.epochMilliseconds : undefined,
+      cmd: this.command.toString(),
+      args: this.body instanceof InvocationBody ? this.body.args : undefined,
+      pol:
+        this.body instanceof DelegationBody
+          ? this.body.policies.map(serializePolicy)
+          : undefined,
+      meta: this.meta,
+      nonce: Buffer.from(this.nonce).toString("hex"),
+      prf:
+        this.proofs && this.proofs.length > 0
+          ? this.proofs.map((proof) => Buffer.from(proof).toString("hex"))
+          : undefined,
+    };
+    return JSON.stringify(token);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,44 +1,5 @@
-import { Temporal } from "temporal-polyfill";
 import { z } from "zod";
-import { Did, NucToken } from "#/token";
-
-const ALPHABET_LABEL = /[a-zA-Z0-9_-]+/;
-const DID_EXPRESSION = /^did:nil:([a-zA-Z0-9]{66})$/;
-
-export const DidSchema = z
-  .string()
-  .transform((did) => DID_EXPRESSION.exec(did))
-  .refine((match) => match !== null, "invalid DID")
-  .transform((match) => Did.fromHex(match[1]));
-
-export const CommandSchema = z
-  .string()
-  .startsWith("/", "command must start with '/'")
-  .transform((selector) => {
-    const s = selector.slice(1);
-    if (!s) return [];
-    return s.split("/");
-  })
-  .refine((labels) => labels.every(Boolean), "empty command")
-  .transform((commands) => {
-    return { segments: commands };
-  });
-export type Command = z.infer<typeof CommandSchema>;
-
-export const SelectorSchema = z
-  .string()
-  .startsWith(".", "selector must start with '.'")
-  .transform((selector) => {
-    const s = selector.slice(1);
-    if (!s) return [];
-    return s.split(".");
-  })
-  .refine((labels) => labels.every(Boolean), "empty attribute")
-  .refine(
-    (labels) => labels.every((label) => ALPHABET_LABEL.test(label)),
-    "invalid attribute character",
-  );
-export type Selector = z.infer<typeof SelectorSchema>;
+import { SelectorSchema } from "#/selector";
 
 export const EqualsSchema = z
   .tuple([z.literal("=="), SelectorSchema, z.unknown()])
@@ -119,53 +80,3 @@ export const PolicySchema: z.ZodType<unknown> = z.lazy(() =>
   z.union([ConnectorSchema, OperatorSchema]),
 );
 export type Policy = z.infer<typeof PolicySchema>;
-
-export const InvocationBodySchema = z.record(z.string(), z.unknown());
-export type InvocationBody = z.infer<typeof InvocationBodySchema>;
-
-export const DelegationBodySchema = z.array(PolicySchema);
-export type DelegationBody = z.infer<typeof DelegationBodySchema>;
-
-export const NucTokenSchema = z
-  .object({
-    iss: DidSchema,
-    aud: DidSchema,
-    sub: DidSchema,
-    nbf: z.number().optional(),
-    exp: z.number().optional(),
-    cmd: CommandSchema,
-    args: InvocationBodySchema.optional(),
-    pol: DelegationBodySchema.optional(),
-    meta: z.record(z.string(), z.unknown()).optional(),
-    nonce: z.string(),
-    prf: z.array(z.string()).optional(),
-  })
-  .transform((token) => {
-    return new NucToken({
-      issuer: token.iss,
-      audience: token.aud,
-      subject: token.sub,
-      command: token.cmd,
-      body: tokenBody(token.args, token.pol),
-      nonce: new Uint8Array(Buffer.from(token.nonce, "hex")),
-      proofs: token.prf?.map((prf) => new Uint8Array(Buffer.from(prf, "hex"))),
-      notBefore: token.nbf
-        ? Temporal.Instant.fromEpochMilliseconds(token.nbf)
-        : undefined,
-      expiresAt: token.exp
-        ? Temporal.Instant.fromEpochMilliseconds(token.exp)
-        : undefined,
-      meta: token.meta,
-    });
-  });
-
-function tokenBody(
-  args: InvocationBody | undefined,
-  pol: DelegationBody | undefined,
-): InvocationBody | DelegationBody {
-  if (args !== undefined && pol !== undefined)
-    throw Error("one of 'args' and 'pol' must be set");
-  if (args !== undefined) return args;
-  if (pol !== undefined) return pol;
-  throw Error("'args' and 'pol' can't both be set");
-}

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -1,0 +1,124 @@
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { Temporal } from "temporal-polyfill";
+import { describe, it } from "vitest";
+import { NucTokenBuilder } from "#/builder";
+import { NucTokenEnvelopeSchema } from "#/envelope";
+import { Selector } from "#/selector";
+import { Command, DelegationBody, Did, NucToken } from "#/token";
+import { base64UrlDecode } from "#/utils";
+
+describe("nuc token builder", () => {
+  it("extend", ({ expect }) => {
+    const key = secp256k1.utils.randomPrivateKey();
+    const base = NucTokenBuilder.delegation([
+      { type: "equals", selector: new Selector(["foo"]), value: 42 },
+    ])
+      .audience(new Did(Uint8Array.from(Array(33).fill(0xbb))))
+      .subject(new Did(Uint8Array.from(Array(33).fill(0xcc))))
+      .command(new Command(["nil", "db", "read"]))
+      .build(key);
+    const baseToken = NucTokenEnvelopeSchema.parse(base);
+
+    const ext = NucTokenBuilder.extending(baseToken)
+      .audience(new Did(Uint8Array.from(Array(33).fill(0xdd))))
+      .build(key);
+    const extToken = NucTokenEnvelopeSchema.parse(ext);
+
+    expect(extToken.token.token.command).toStrictEqual(
+      baseToken.token.token.command,
+    );
+    expect(extToken.token.token.subject).toStrictEqual(
+      baseToken.token.token.subject,
+    );
+    expect(extToken.proofs.length).toBe(1);
+    expect(extToken.proofs[0]).toStrictEqual(baseToken.token);
+  });
+
+  it("encode decode", ({ expect }) => {
+    const key = secp256k1.utils.randomPrivateKey();
+    const token = NucTokenBuilder.delegation([])
+      .audience(new Did(Uint8Array.from(Array(33).fill(0xbb))))
+      .subject(new Did(Uint8Array.from(Array(33).fill(0xcc))))
+      .command(new Command(["nil", "db", "read"]))
+      .notBefore(Temporal.Instant.fromEpochMilliseconds(1740494955))
+      .expiresAt(Temporal.Instant.fromEpochMilliseconds(1740495955))
+      .nonce(new Uint8Array([1, 2, 3]))
+      .meta({ name: "bob" })
+      .build(key);
+    const envelope = NucTokenEnvelopeSchema.parse(token);
+    envelope.validateSignatures();
+
+    const [header, _] = token.split(".");
+    expect(JSON.parse(base64UrlDecode(header))).toStrictEqual({
+      alg: "ES256K",
+    });
+
+    const expectedToken = new NucToken({
+      issuer: new Did(secp256k1.getPublicKey(key)),
+      audience: new Did(Uint8Array.from(Array(33).fill(0xbb))),
+      subject: new Did(Uint8Array.from(Array(33).fill(0xcc))),
+      command: new Command(["nil", "db", "read"]),
+      notBefore: Temporal.Instant.fromEpochMilliseconds(1740494955),
+      expiresAt: Temporal.Instant.fromEpochMilliseconds(1740495955),
+      nonce: new Uint8Array([1, 2, 3]),
+      meta: { name: "bob" },
+      body: new DelegationBody([]),
+      proofs: [],
+    });
+    expect(envelope.token.token).toStrictEqual(expectedToken);
+  });
+
+  it("chain", ({ expect }) => {
+    const rootKey = secp256k1.utils.randomPrivateKey();
+    const rootToken = NucTokenBuilder.delegation([
+      { type: "equals", selector: new Selector(["foo"]), value: 42 },
+    ])
+      .audience(new Did(Uint8Array.from(Array(33).fill(0xbb))))
+      .subject(new Did(Uint8Array.from(Array(33).fill(0xcc))))
+      .command(new Command(["nil", "db", "read"]))
+      .build(rootKey);
+    const root = NucTokenEnvelopeSchema.parse(rootToken);
+    root.validateSignatures();
+
+    const otherKey = secp256k1.utils.randomPrivateKey();
+    const otherToken = NucTokenBuilder.delegation([
+      { type: "equals", selector: new Selector(["foo"]), value: 42 },
+    ])
+      .audience(new Did(Uint8Array.from(Array(33).fill(0xbb))))
+      .subject(new Did(Uint8Array.from(Array(33).fill(0xcc))))
+      .command(new Command(["nil", "db", "read"]))
+      .proof(root)
+      .build(otherKey);
+    const delegation = NucTokenEnvelopeSchema.parse(otherToken);
+    delegation.validateSignatures();
+
+    expect(delegation.token.token.proofs).toStrictEqual([
+      root.token.computeHash(),
+    ]);
+    expect(delegation.proofs.length).toBe(1);
+    expect(delegation.proofs[0]).toStrictEqual(root.token);
+
+    const yetAnotherKey = secp256k1.utils.randomPrivateKey();
+    const yetAnotherToken = NucTokenBuilder.invocation({ beep: 42 })
+      .audience(new Did(Uint8Array.from(Array(33).fill(0xbb))))
+      .subject(new Did(Uint8Array.from(Array(33).fill(0xcc))))
+      .command(new Command(["nil", "db", "read"]))
+      .proof(delegation)
+      .build(yetAnotherKey);
+    const invocation = NucTokenEnvelopeSchema.parse(yetAnotherToken);
+    invocation.validateSignatures();
+
+    expect(invocation.token.token.proofs).toStrictEqual([
+      delegation.token.computeHash(),
+    ]);
+    expect(invocation.proofs.length).toBe(2);
+    expect(invocation.proofs[0]).toStrictEqual(delegation.token);
+    expect(invocation.proofs[1]).toStrictEqual(root.token);
+  });
+
+  it("decode specific", () => {
+    const token =
+      "eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAyMjZhNGQ0YTRhNWZhZGUxMmM1ZmYwZWM5YzQ3MjQ5ZjIxY2Y3N2EyMDI3NTFmOTU5ZDVjNzc4ZjBiNjUyYjcxNiIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJhcmdzIjp7ImZvbyI6NDJ9LCJub25jZSI6IjAxMDIwMyIsInByZiI6WyJjOTA0YzVhMWFiMzY5YWVhMWI0ZDlkMTkwMmE0NmU2ZWY5NGFhYjk2OTY0YmI1MWQ2MWE2MWIwM2UyM2Q1ZGZmIl19.ufDYxqoSVNVETrVKReu0h_Piul5c6RoC_VnGGLw04mkyn2OMrtQjK92sGXNHCjlp7T9prIwxX14ZB_N3gx7hPg/eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAzNmY3MDdmYmVmMGI3NTIxMzgwOGJiYmY1NGIxODIxNzZmNTMyMGZhNTIwY2I4MTlmMzViNWJhZjIzMjM4YTAxNSIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJwb2wiOltbIj09IiwiLmZvbyIsNDJdXSwibm9uY2UiOiIwMTAyMDMiLCJwcmYiOlsiODZjZGI1ZjZjN2M3NDFkMDBmNmI4ODMzZDI0ZjdlY2Y5MWFjOGViYzI2MzA3MmZkYmU0YTZkOTQ5NzIwMmNiNCJdfQ.drGzkA0hYP8h62GxNN3fhi9bKjYgjpSy4cM52-9RsyB7JD6O6K1wRsg_x1hv8ladPmChpwDVVXOzjNr2NRVntA/eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAzOTU5MGNjYWYxMDI0ZjQ5YzljZjc0M2Y4YTZlZDQyMDNlNzgyZThlZTA5YWZhNTNkMWI1NzY0OTg0NjEyMzQyNSIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJwb2wiOltbIj09IiwiLmZvbyIsNDJdXSwibm9uY2UiOiIwMTAyMDMiLCJwcmYiOltdfQ.o3lnQxCjDCW10UuRABrHp8FpB_C6q1xgEGvfuXTb7Epp63ry8R2h0wHjToDKDFmkmUmO2jcBkrttuy8kftV6og";
+    NucTokenEnvelopeSchema.parse(token).validateSignatures();
+  });
+});

--- a/tests/envelope.test.ts
+++ b/tests/envelope.test.ts
@@ -18,14 +18,14 @@ describe("parse envelope", () => {
     const token = NucTokenEnvelopeSchema.parse(rawToken);
     token.validateSignatures();
     expect(token.proofs.length).toBe(2);
-    expect(token.proofs[0].issuer.publicKey).toStrictEqual(
+    expect(token.proofs[0].token.issuer.publicKey).toStrictEqual(
       new Uint8Array([
         3, 111, 112, 127, 190, 240, 183, 82, 19, 128, 139, 187, 245, 75, 24, 33,
         118, 245, 50, 15, 165, 32, 203, 129, 159, 53, 181, 186, 242, 50, 56,
         160, 21,
       ]),
     );
-    expect(token.proofs[1].issuer.publicKey).toStrictEqual(
+    expect(token.proofs[1].token.issuer.publicKey).toStrictEqual(
       new Uint8Array([
         3, 149, 144, 204, 175, 16, 36, 244, 156, 156, 247, 67, 248, 166, 237,
         66, 3, 231, 130, 232, 238, 9, 175, 165, 61, 27, 87, 100, 152, 70, 18,

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,27 +1,44 @@
 import { describe, it } from "vitest";
 import { evaluatePolicy } from "#/policy";
+import { Selector } from "#/selector";
 import { OperatorSchema, type Policy, PolicySchema } from "#/types";
 
 describe.each([
   {
     test: "eq",
     input: ["==", ".foo", { ".bar": 42 }],
-    expected: { type: "equals", selector: ["foo"], value: { ".bar": 42 } },
+    expected: {
+      type: "equals",
+      selector: new Selector(["foo"]),
+      value: { ".bar": 42 },
+    },
   },
   {
     test: "ne",
     input: ["!=", ".foo", { ".bar": 42 }],
-    expected: { type: "notEquals", selector: ["foo"], value: { ".bar": 42 } },
+    expected: {
+      type: "notEquals",
+      selector: new Selector(["foo"]),
+      value: { ".bar": 42 },
+    },
   },
   {
     test: "anyOf1",
     input: ["anyOf", ".foo", [42, "hi"]],
-    expected: { type: "anyOf", selector: ["foo"], options: [42, "hi"] },
+    expected: {
+      type: "anyOf",
+      selector: new Selector(["foo"]),
+      options: [42, "hi"],
+    },
   },
   {
     test: "anyOf2",
     input: ["anyOf", ".foo", [{ foo: 42 }]],
-    expected: { type: "anyOf", selector: ["foo"], options: [{ foo: 42 }] },
+    expected: {
+      type: "anyOf",
+      selector: new Selector(["foo"]),
+      options: [{ foo: 42 }],
+    },
   },
   {
     test: "and",
@@ -35,8 +52,8 @@ describe.each([
     expected: {
       type: "and",
       conditions: [
-        { type: "equals", selector: ["foo"], value: 42 },
-        { type: "notEquals", selector: ["bar"], value: false },
+        { type: "equals", selector: new Selector(["foo"]), value: 42 },
+        { type: "notEquals", selector: new Selector(["bar"]), value: false },
       ],
     },
   },
@@ -52,8 +69,8 @@ describe.each([
     expected: {
       type: "or",
       conditions: [
-        { type: "equals", selector: ["foo"], value: 42 },
-        { type: "notEquals", selector: ["bar"], value: false },
+        { type: "equals", selector: new Selector(["foo"]), value: 42 },
+        { type: "notEquals", selector: new Selector(["bar"]), value: false },
       ],
     },
   },
@@ -62,7 +79,7 @@ describe.each([
     input: ["not", ["==", ".foo", 42]],
     expected: {
       type: "not",
-      condition: { type: "equals", selector: ["foo"], value: 42 },
+      condition: { type: "equals", selector: new Selector(["foo"]), value: 42 },
     },
   },
   {
@@ -83,14 +100,18 @@ describe.each([
     expected: {
       type: "or",
       conditions: [
-        { type: "equals", selector: ["foo"], value: 42 },
+        { type: "equals", selector: new Selector(["foo"]), value: 42 },
         {
           type: "and",
           conditions: [
-            { type: "notEquals", selector: ["bar"], value: 1337 },
+            { type: "notEquals", selector: new Selector(["bar"]), value: 1337 },
             {
               type: "not",
-              condition: { type: "equals", selector: ["tar"], value: true },
+              condition: {
+                type: "equals",
+                selector: new Selector(["tar"]),
+                value: true,
+              },
             },
           ],
         },
@@ -127,17 +148,25 @@ describe.each([
 describe.each([
   {
     test: "eq value",
-    policy: { type: "equals", selector: ["name", "first"], value: "bob" },
+    policy: {
+      type: "equals",
+      selector: new Selector(["name", "first"]),
+      value: "bob",
+    },
   },
   {
     test: "ne",
-    policy: { type: "notEquals", selector: ["name", "first"], value: "john" },
+    policy: {
+      type: "notEquals",
+      selector: new Selector(["name", "first"]),
+      value: "john",
+    },
   },
   {
     test: "eq object",
     policy: {
       type: "equals",
-      selector: ["name"],
+      selector: new Selector(["name"]),
       value: { first: "bob", last: "smith" },
     },
   },
@@ -145,19 +174,19 @@ describe.each([
     test: "eq root",
     policy: {
       type: "equals",
-      selector: [],
+      selector: new Selector([]),
       value: { name: { first: "bob", last: "smith" }, age: 42 },
     },
   },
   {
     test: "notEq",
-    policy: { type: "notEquals", selector: ["age"], value: 150 },
+    policy: { type: "notEquals", selector: new Selector(["age"]), value: 150 },
   },
   {
     test: "anyOf",
     policy: {
       type: "anyOf",
-      selector: ["name", ["first"]],
+      selector: new Selector(["name", "first"]),
       options: ["john", "bob"],
     },
   },
@@ -166,8 +195,12 @@ describe.each([
     policy: {
       type: "and",
       conditions: [
-        { type: "equals", selector: ["age"], value: 42 },
-        { type: "equals", selector: ["name", "first"], value: "bob" },
+        { type: "equals", selector: new Selector(["age"]), value: 42 },
+        {
+          type: "equals",
+          selector: new Selector(["name", "first"]),
+          value: "bob",
+        },
       ],
     },
   },
@@ -176,8 +209,8 @@ describe.each([
     policy: {
       type: "or",
       conditions: [
-        { type: "equals", selector: ["age"], value: 42 },
-        { type: "equals", selector: ["age"], value: 100 },
+        { type: "equals", selector: new Selector(["age"]), value: 42 },
+        { type: "equals", selector: new Selector(["age"]), value: 100 },
       ],
     },
   },
@@ -186,8 +219,8 @@ describe.each([
     policy: {
       type: "or",
       conditions: [
-        { type: "equals", selector: ["age"], value: 100 },
-        { type: "equals", selector: ["age"], value: 42 },
+        { type: "equals", selector: new Selector(["age"]), value: 100 },
+        { type: "equals", selector: new Selector(["age"]), value: 42 },
       ],
     },
   },
@@ -208,17 +241,25 @@ describe.each([
 describe.each([
   {
     test: "eq value",
-    policy: { type: "equals", selector: ["name", "first"], value: "john" },
+    policy: {
+      type: "equals",
+      selector: new Selector(["name", "first"]),
+      value: "john",
+    },
   },
   {
     test: "ne",
-    policy: { type: "notEquals", selector: ["name", "first"], value: "bob" },
+    policy: {
+      type: "notEquals",
+      selector: new Selector(["name", "first"]),
+      value: "bob",
+    },
   },
   {
     test: "eq object",
     policy: {
       type: "equals",
-      selector: ["name"],
+      selector: new Selector(["name"]),
       value: { first: "john", last: "smith" },
     },
   },
@@ -226,19 +267,19 @@ describe.each([
     test: "eq root",
     policy: {
       type: "equals",
-      selector: [],
+      selector: new Selector([]),
       value: { name: { first: "bob", last: "smith" }, age: 100 },
     },
   },
   {
     test: "notEq",
-    policy: { type: "notEquals", selector: ["age"], value: 42 },
+    policy: { type: "notEquals", selector: new Selector(["age"]), value: 42 },
   },
   {
     test: "anyOf",
     policy: {
       type: "anyOf",
-      selector: ["name", ["first"]],
+      selector: new Selector(["name", "first"]),
       options: ["john", "jack"],
     },
   },
@@ -247,8 +288,12 @@ describe.each([
     policy: {
       type: "and",
       conditions: [
-        { type: "equals", selector: ["age"], value: 150 },
-        { type: "equals", selector: ["name", "first"], value: "bob" },
+        { type: "equals", selector: new Selector(["age"]), value: 150 },
+        {
+          type: "equals",
+          selector: new Selector(["name", "first"]),
+          value: "bob",
+        },
       ],
     },
   },
@@ -257,8 +302,12 @@ describe.each([
     policy: {
       type: "and",
       conditions: [
-        { type: "equals", selector: ["age"], value: 42 },
-        { type: "equals", selector: ["name", "first"], value: "john" },
+        { type: "equals", selector: new Selector(["age"]), value: 42 },
+        {
+          type: "equals",
+          selector: new Selector(["name", "first"]),
+          value: "john",
+        },
       ],
     },
   },
@@ -268,8 +317,8 @@ describe.each([
     policy: {
       type: "or",
       conditions: [
-        { type: "equals", selector: ["age"], value: 101 },
-        { type: "equals", selector: ["age"], value: 100 },
+        { type: "equals", selector: new Selector(["age"]), value: 101 },
+        { type: "equals", selector: new Selector(["age"]), value: 100 },
       ],
     },
   },

--- a/tests/selector.test.ts
+++ b/tests/selector.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "vitest";
-import { applySelector } from "#/selector";
-import { OperatorSchema, SelectorSchema } from "#/types";
+import { Selector, SelectorSchema } from "#/selector";
+import { OperatorSchema } from "#/types";
 
 describe.each([
   { test: "identity", input: ".", path: [] },
@@ -14,7 +14,7 @@ describe.each([
 ])("valid policy", ({ test, input, path }) => {
   it(`${test}`, ({ expect }) => {
     const result = SelectorSchema.parse(input);
-    expect(result).toEqual(path);
+    expect(result).toEqual(new Selector(path));
   });
 });
 
@@ -48,7 +48,7 @@ describe.each([
   { test: "non_existent", selector: ".foo", input: { bar: 42 } },
 ])("lookup", ({ test, selector, input, expected }) => {
   it(`${test}`, ({ expect }) => {
-    const result = applySelector(SelectorSchema.parse(selector), input);
+    const result = SelectorSchema.parse(selector).apply(input);
     expect(result).toEqual(expected);
   });
 });

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -1,7 +1,16 @@
 import { Temporal } from "temporal-polyfill";
 import { describe, it } from "vitest";
-import { Did, NucToken } from "#/token";
-import { CommandSchema, DidSchema, NucTokenSchema } from "#/types";
+import { Selector } from "#/selector";
+import {
+  Command,
+  CommandSchema,
+  DelegationBody,
+  Did,
+  DidSchema,
+  InvocationBody,
+  NucToken,
+  NucTokenSchema,
+} from "#/token";
 
 describe.each([
   { test: "root", input: "/", expected: { segments: [] } },
@@ -89,12 +98,12 @@ describe("parse token", () => {
           204, 204, 204, 204, 204,
         ]),
       ),
-      command: {
-        segments: ["nil", "db", "read"],
-      },
-      body: [{ type: "equals", selector: ["foo"], value: 42 }],
+      command: new Command(["nil", "db", "read"]),
+      body: new DelegationBody([
+        { type: "equals", selector: new Selector(["foo"]), value: 42 },
+      ]),
       nonce: new Uint8Array([190, 239]),
-      proofs: undefined,
+      proofs: [],
       notBefore: undefined,
       expiresAt: undefined,
       meta: undefined,
@@ -140,8 +149,10 @@ describe("parse token", () => {
           204, 204, 204, 204, 204,
         ]),
       ),
-      command: { segments: ["nil", "db", "read"] },
-      body: [{ type: "equals", selector: ["foo"], value: 42 }],
+      command: new Command(["nil", "db", "read"]),
+      body: new DelegationBody([
+        { type: "equals", selector: new Selector(["foo"]), value: 42 },
+      ]),
       nonce: new Uint8Array([190, 239]),
       proofs: [
         new Uint8Array([
@@ -189,12 +200,10 @@ describe("parse token", () => {
           204, 204, 204, 204, 204,
         ]),
       ),
-      command: {
-        segments: ["nil", "db", "read"],
-      },
-      body: { bar: 42 },
+      command: new Command(["nil", "db", "read"]),
+      body: new InvocationBody({ bar: 42 }),
       nonce: new Uint8Array([190, 239]),
-      proofs: undefined,
+      proofs: [],
       notBefore: undefined,
       expiresAt: undefined,
       meta: undefined,
@@ -240,8 +249,8 @@ describe("parse token", () => {
           204, 204, 204, 204, 204,
         ]),
       ),
-      command: { segments: ["nil", "db", "read"] },
-      body: { bar: 42 },
+      command: new Command(["nil", "db", "read"]),
+      body: new InvocationBody({ bar: 42 }),
       nonce: new Uint8Array([190, 239]),
       proofs: [
         new Uint8Array([


### PR DESCRIPTION
This adds support for nuc builder and serialization.

This PR refactors some parts of the code to simplify the handing of the token and its parts. I want to do something similar with the policies, but I'll do it in a follow up. It wasn't mandatory for this PR and it would have added noise.