### PR TITLE
chore: simplify type conversions

### DIFF
--- a/src/envelope.ts
+++ b/src/envelope.ts
@@ -1,5 +1,6 @@
-import { createHash } from "node:crypto";
 import { secp256k1 } from "@noble/curves/secp256k1";
+import { sha256 } from "@noble/hashes/sha256";
+import { toBytes } from "@noble/hashes/utils";
 import { z } from "zod";
 import { type NucToken, NucTokenSchema } from "#/token";
 import {
@@ -84,12 +85,12 @@ export class DecodedNucToken {
    * Validate the signature in this token.
    */
   validateSignature() {
-    const signature = this.signature;
-    const msg = new Uint8Array(
-      Buffer.from(`${this.rawHeader}.${this.rawPayload}`),
-    );
-    const publicKey = new Uint8Array(Buffer.from(this.token.issuer.publicKey));
-    if (!secp256k1.verify(signature, msg, publicKey, { prehash: true })) {
+    const msg = toBytes(`${this.rawHeader}.${this.rawPayload}`);
+    if (
+      !secp256k1.verify(this.signature, msg, this.token.issuer.publicKey, {
+        prehash: true,
+      })
+    ) {
       throw new Error(SIGNATURE_VERIFICATION_FAILED);
     }
   }
@@ -98,9 +99,7 @@ export class DecodedNucToken {
    * Compute the hash for this token.
    */
   computeHash(): Uint8Array {
-    return Uint8Array.from(
-      createHash("sha256").update(this.serialize()).digest(),
-    );
+    return sha256(this.serialize());
   }
 
   /**

--- a/src/keypair.ts
+++ b/src/keypair.ts
@@ -25,8 +25,7 @@ export class Keypair {
    * @param format - Output encoding (default: bytes in an Uint8Array)
    * @returns Private key in requested format
    */
-  privateKey(): Uint8Array;
-  privateKey(format: "bytes"): Uint8Array;
+  privateKey(format?: "bytes"): Uint8Array;
   privateKey(format: "hex"): string;
   privateKey(format?: KeyFormat): Uint8Array | string {
     return format === "hex"
@@ -39,8 +38,7 @@ export class Keypair {
    * @param format - Output encoding (default: bytes in an Uint8Array)
    * @returns Public key in requested format
    */
-  publicKey(): Uint8Array;
-  publicKey(format: "bytes"): Uint8Array;
+  publicKey(format?: "bytes"): Uint8Array;
   publicKey(format: "hex"): string;
   publicKey(format?: KeyFormat): Uint8Array | string {
     return format === "hex"
@@ -83,5 +81,23 @@ export class Keypair {
    */
   static generate(): Keypair {
     return new Keypair(secp256k1.utils.randomPrivateKey());
+  }
+
+  /**
+   * Signs a message
+   * @param msg Message to sign
+   * @param signatureFormat Result format. Only "hex" and "bytes" are valid (default: bytes in an Uint8Array).
+   * @return The signature in raw bytes or hex string, depending on the given format.
+   */
+  sign(msg: string, signatureFormat?: "bytes"): Uint8Array;
+  sign(msg: string, signatureFormat: "hex"): string;
+  sign(msg: string, signatureFormat?: "bytes" | "hex"): Uint8Array | string {
+    const msgHash = Uint8Array.from(Buffer.from(msg));
+    const signature = secp256k1.sign(msgHash, this.privateKey(), {
+      prehash: true,
+    });
+    return signatureFormat === "hex"
+      ? signature.toCompactHex()
+      : signature.toCompactRawBytes();
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,13 @@
+import { z } from "zod";
+
+export const HexSchema = z.string().regex(/^[a-fA-F0-9]+$/, "invalid hex");
+export type Hex = z.infer<typeof HexSchema>;
+
+export function toHex(input: string | Record<string, unknown>): Hex {
+  const data = typeof input === "string" ? input : JSON.stringify(input);
+  return Buffer.from(data).toString("hex");
+}
+
 /**
  * Encode URL safe base64.
  * @param input data to be encoded.

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -43,7 +43,7 @@ describe("nuc token builder", () => {
       .command(new Command(["nil", "db", "read"]))
       .notBefore(Temporal.Instant.fromEpochSeconds(1740494955))
       .expiresAt(Temporal.Instant.fromEpochSeconds(1740495955))
-      .nonce(new Uint8Array([1, 2, 3]))
+      .nonce("010203")
       .meta({ name: "bob" })
       .build(key);
     const envelope = NucTokenEnvelopeSchema.parse(token);
@@ -61,7 +61,7 @@ describe("nuc token builder", () => {
       command: new Command(["nil", "db", "read"]),
       notBefore: Temporal.Instant.fromEpochSeconds(1740494955),
       expiresAt: Temporal.Instant.fromEpochSeconds(1740495955),
-      nonce: new Uint8Array([1, 2, 3]),
+      nonce: "010203",
       meta: { name: "bob" },
       body: new DelegationBody([]),
       proofs: [],

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -118,7 +118,7 @@ describe("parse token", () => {
       ),
       command: new Command(["nil", "db", "read"]),
       body: new DelegationBody([new Equals(new Selector(["foo"]), 42)]),
-      nonce: new Uint8Array([190, 239]),
+      nonce: "beef",
       proofs: [],
       notBefore: undefined,
       expiresAt: undefined,
@@ -167,7 +167,7 @@ describe("parse token", () => {
       ),
       command: new Command(["nil", "db", "read"]),
       body: new DelegationBody([new Equals(new Selector(["foo"]), 42)]),
-      nonce: new Uint8Array([190, 239]),
+      nonce: "beef",
       proofs: [
         new Uint8Array([
           244, 240, 74, 246, 168, 50, 188, 216, 166, 133, 93, 245, 208, 36, 44,
@@ -216,7 +216,7 @@ describe("parse token", () => {
       ),
       command: new Command(["nil", "db", "read"]),
       body: new InvocationBody({ bar: 42 }),
-      nonce: new Uint8Array([190, 239]),
+      nonce: "beef",
       proofs: [],
       notBefore: undefined,
       expiresAt: undefined,
@@ -265,7 +265,7 @@ describe("parse token", () => {
       ),
       command: new Command(["nil", "db", "read"]),
       body: new InvocationBody({ bar: 42 }),
-      nonce: new Uint8Array([190, 239]),
+      nonce: "beef",
       proofs: [
         new Uint8Array([
           244, 240, 74, 246, 168, 50, 188, 216, 166, 133, 93, 245, 208, 36, 44,


### PR DESCRIPTION
This adds some utiliities to convert types and avoid using much Buffer conversion directly.

In addition, this removes unneded type conversion for NucToken's nonce.