### PR TITLE
fix: check that the version is higher to avoid publishing

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -10,37 +10,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish:
+  check-version:
     runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.version-check.outputs.local_version_is_higher }}
+      tag: ${{ steps.version-check.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
-
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
           version: "0.4.24"
-
       - name: Set up Python
         run: uv python install
-
       - name: Check version
         id: check-version
         run: >-
           cd scripts/version_checker && uv run ./version_checker.py ../../
 
+  publish:
+    needs: check-version
+    if: needs.check-version.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
       - uses: actions/setup-node@v4
         with:
           node-version: "23"
           registry-url: "https://registry.npmjs.org"
-
       - uses: pnpm/action-setup@v4
-
       - run: pnpm install
       - run: pnpm build
       - run: pnpm exec biome ci
       - run: tsc
       - env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --tag ${{ steps.check-version.outputs.tag }}
+        run: pnpm publish --tag ${{ needs.check-version.outputs.tag }} --no-git-checks


### PR DESCRIPTION
This checks that the version is higher before trying to publish a new version. In addition, this adds the tag --no-git-checks, which is needed to avoid failures when submodules are not updated.