### PR TITLE
chore!: use epoch timestamp for revoked token timestamp field

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - "26648:26648" # JSON RPC
 
   nilauth:
-    image: public.ecr.aws/k5d9x2g2/nilauth:f4f8f682f53356deeec2c0f206b6bd5b98c21095
+    image: public.ecr.aws/k5d9x2g2/nilauth:a76ec51c4db044a0838d1aa5b15f4143009bd37e
     depends_on:
       - db
       - nilchain

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nillion/nuc",
-  "version": "0.1.0-rc.7",
+  "version": "0.1.0-rc.8",
   "license": "MIT",
   "repository": "https://github.com/NillionNetwork/nuc-ts",
   "engines": {

--- a/src/nilauth/types.ts
+++ b/src/nilauth/types.ts
@@ -84,11 +84,11 @@ export type CreateTokenResponse = z.infer<typeof CreateTokenResponseSchema>;
 export const RevokedTokenSchema = z
   .object({
     token_hash: z.string(),
-    revoked_at: z.string(),
+    revoked_at: z.number(),
   })
   .transform(({ token_hash, revoked_at }) => ({
     tokenHash: token_hash,
-    revokedAt: revoked_at,
+    revokedAt: Temporal.Instant.fromEpochMilliseconds(revoked_at * 1000),
   }));
 export type RevokedToken = z.output<typeof RevokedTokenSchema>;
 


### PR DESCRIPTION
Client changes for https://github.com/NillionNetwork/nilauth/pull/42. Tests will fail until that PR is merged and the docker image is updated.