### PR TITLE
chore: log payment payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nillion/nuc",
-  "version": "0.1.0-rc.9",
+  "version": "0.1.0-rc.10",
   "license": "MIT",
   "repository": "https://github.com/NillionNetwork/nuc-ts",
   "engines": {

--- a/src/nilauth/client.ts
+++ b/src/nilauth/client.ts
@@ -405,9 +405,12 @@ export class NilauthClient {
       blind_module: blindModule,
     });
     const payloadHex = toHex(payload);
+    const payloadDigest = sha256(payload);
+    log(
+      `Making payment with payload=${payloadHex}, digest=${bytesToHex(payloadDigest)}`,
+    );
 
     const request = {
-      payload: payloadHex,
       hash: sha256(payload),
       cost: amount,
     };


### PR DESCRIPTION
This logs the payload and digest, both in hex. This can be used to reconstruct the input to the payment and perform anything needed in case payments go wrong.